### PR TITLE
Fix for binary data read

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ Octavian = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
 BenchmarkTools = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Grant Hecht"]
 version = "0.1.1"
 
 [deps]
+BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"

--- a/src/CR3BP/cr3bpOptEoms.jl
+++ b/src/CR3BP/cr3bpOptEoms.jl
@@ -196,6 +196,85 @@ function cr3bpEomIndirect!(du::AbstractVector, u::AbstractVector,
     return GVec
 end
 
+function cr3bpEomIndirectEnergyIntegral(u::AbstractVector, p::AbstractCR3BPIndirectParams, t)
+    @inbounds begin
+
+    # Get requirements 
+    TU  = p.crp.TU
+    LU  = p.crp.LU
+    VU  = p.crp.VU 
+    MU  = p.crp.MU 
+    isp = p.sp.isp 
+    c   = p.sp.c
+
+    # Scale requirements
+    tMaxSc = p.sp.tMax * TU * TU / (MU*LU*1000.0)
+    cSc = c*TU / (LU*1000.0)
+
+    # Compute thrust direction
+    λv = sqrt(u[11]*u[11] + u[12]*u[12] + u[13]*u[13])
+    invλv = 1.0 / λv 
+    α = @SVector [-u[11]*invλv, -u[12]*invλv, -u[13]*invλv]
+
+    # Compute throttline 
+    S = computeS(u, λv, cSc)
+    γ = computeU(S, p.utype, p.ϵ)
+
+    # Compute Thrust Acceleration
+    atMag = γ*tMaxSc / u[7]
+    at = @SVector [α[1]*atMag,
+                   α[2]*atMag,
+                   α[3]*atMag]
+
+    # Derivatives
+    dx      = cr3bpEomControl(u,p.crp,t,at)
+    dλ      = cr3bpCostateEom(u,p, γ)
+    usqr    = γ^2
+    du = @SVector [dx[1], dx[2], dx[3], dx[4], dx[5], dx[6], -γ*tMaxSc / cSc,
+                   dλ[1], dλ[2], dλ[3], dλ[4], dλ[5], dλ[6], dλ[7], usqr]
+
+    return du
+    end
+end
+
+function cr3bpEomIndirectEnergyIntegral!(du::AbstractArray, u::AbstractArray, p::AbstractCR3BPIndirectParams, t)
+    @inbounds begin
+    # Get requirements 
+    TU  = p.crp.TU
+    LU  = p.crp.LU
+    VU  = p.crp.VU 
+    MU  = p.crp.MU 
+    isp = p.sp.isp 
+    c   = p.sp.c
+
+    # Scale requirements
+    tMaxSc = p.sp.tMax * TU^2 / (MU*LU*1000.0)
+    cSc = c*TU / (LU*1000.0)
+
+    # Compute thrust direction
+    λv = sqrt(u[11]^2 + u[12]^2 + u[13]^2)
+    invλv = 1.0 / λv 
+    α = @SVector [-u[11]*invλv, -u[12]*invλv, -u[13]*invλv]
+
+    # Compute throttline 
+    S = computeS(u, λv, cSc)
+    γ = computeU(S, p.utype, p.ϵ)
+
+    # Compute Thrust Acceleration
+    atMag = γ*tMaxSc / u[7]
+    at = @SVector [α[1]*atMag,
+                   α[2]*atMag,
+                   α[3]*atMag]
+
+    # Compute dynamics
+    cr3bpEomControl!(view(du,1:6), u, p.crp, t, at)
+    du[7]   = -γ*tMaxSc / cSc
+    GVec    = cr3bpCostateEom!(view(du,8:14), u, p, γ)
+    du[15]  = γ^2
+    end
+    return GVec
+end
+
 # Utility Functions 
 function computeS(x::AbstractVector, λv, cSc)
     @inbounds begin

--- a/src/DataOutputManager.jl
+++ b/src/DataOutputManager.jl
@@ -68,7 +68,8 @@ function writeData(dom::DataOutputManager, ito)
 end
 
 function writeBinaryData(dom::DataOutputManager, ito)
-    jldsave(joinpath(dom.baseFolder, "binaryData", dom.fname*".jld2"), data = ito)
+    #jldsave(joinpath(dom.baseFolder, "binaryData", dom.fname*".jld2"), data = ito)
+    bson(joinpath(dom.baseFolder, "binaryData", dom.fname*".bson"), Dict(:data=>ito))
     return nothing
 end
 

--- a/src/IndirectTrajOpt.jl
+++ b/src/IndirectTrajOpt.jl
@@ -7,6 +7,7 @@ using Reexport
 import IndirectCoStateInit: initialize!
 import IndirectShooting: solve!
 using JLD2
+using BSON
 using DataFrames
 using ProgressMeter
 using Suppressor

--- a/src/IndirectTrajOpt.jl
+++ b/src/IndirectTrajOpt.jl
@@ -9,6 +9,7 @@ import IndirectShooting: solve!
 using JLD2
 using DataFrames
 using ProgressMeter
+using Suppressor
 
 # This stuff should be moved to a different package eventually
 using StaticArrays

--- a/src/IndirectTrajOptimizer.jl
+++ b/src/IndirectTrajOptimizer.jl
@@ -1,5 +1,6 @@
+abstract type AbstractIndirectTrajOptimizer end
 
-struct IndirectTrajOptimizer{IPT,CSIT,ST}
+struct IndirectTrajOptimizer{IPT,CSIT,ST} <: AbstractIndirectOptimizationProblem
     # Indirect Trajectory Optimization problem 
     prob::IPT
 

--- a/src/Utils/flagStructs.jl
+++ b/src/Utils/flagStructs.jl
@@ -2,6 +2,10 @@
 # Dynamics model flags
 struct CR3BP end
 
+# Homotopy flags
+struct MEMF end     # Min. Energy -> Min. Fuel 
+struct HypTanMF end # Hyperbolic Tangent Minimum Fuel 
+
 # Desired integration and returned solution
 # Flag indicating integration to be performed for initialization cost function
 #

--- a/src/Utils/readData.jl
+++ b/src/Utils/readData.jl
@@ -15,19 +15,23 @@ function readBinaryData(folder::String)
     local dataVec
     @showprogress "Reading Binary Data Files: " for i in 1:length(files)
         # Open file
-        f = jldopen(joinpath(folder, "binaryData", files[i]), "r")
+        #f = jldopen(joinpath(folder, "binaryData", files[i]), "r")
+        data = get(BSON.load(joinpath(folder, "binaryData", files[i]), @__MODULE__), :data, nothing)
+        if data === nothing
+            throw(ErrorException("Binary file was not read succesfully."))
+        end
 
         # Grab data and push to vector
         @suppress begin
             if i == 1
-                dataVec = Vector{AbstractIndirectOptimizationProblem}([f["data"]])
+                dataVec = Vector{AbstractIndirectOptimizationProblem}([data])
             else
-                push!(dataVec, f["data"])
+                push!(dataVec, data)
             end
         end
 
         # Close file
-        close(f)
+        #close(f)
     end
 
     return dataVec

--- a/src/Utils/readData.jl
+++ b/src/Utils/readData.jl
@@ -18,10 +18,12 @@ function readBinaryData(folder::String)
         f = jldopen(joinpath(folder, "binaryData", files[i]), "r")
 
         # Grab data and push to vector
-        if i == 1
-            dataVec = [f["data"]]
-        else
-            push!(dataVec, f["data"])
+        @suppress begin
+            if i == 1
+                dataVec = Vector{AbstractIndirectOptimizationProblem}([f["data"]])
+            else
+                push!(dataVec, f["data"])
+            end
         end
 
         # Close file


### PR DESCRIPTION
JLD2.jl was causing some issues with reloading IndirectTrajOptimizer objects which had functions as fields. Switched to BSON.jl, which seems to have less of an issues.

Also added new EOMs for computing integral cost terms and structs to be used as flags.